### PR TITLE
Create generic RepositoryResult with TError

### DIFF
--- a/src/Dangl.Data.Shared/RepositoryResult.cs
+++ b/src/Dangl.Data.Shared/RepositoryResult.cs
@@ -72,6 +72,13 @@ namespace Dangl.Data.Shared
                 Value = value
             };
         }
+
+        /// <summary>
+        /// Converts a value to a successful result
+        /// </summary>
+        /// <param name="value">The value to convert</param>
+        public static implicit operator RepositoryResult<TResult, TError>(TResult value) =>
+            Success(value);
     }
 
     /// <summary>
@@ -140,6 +147,13 @@ namespace Dangl.Data.Shared
                 Value = value
             };
         }
+
+        /// <summary>
+        /// Converts a value to a successful result
+        /// </summary>
+        /// <param name="value">The value to convert</param>
+        public static implicit operator RepositoryResult<TResult>(TResult value) =>
+            Success(value);
     }
 
     /// <summary>

--- a/src/Dangl.Data.Shared/RepositoryResult.cs
+++ b/src/Dangl.Data.Shared/RepositoryResult.cs
@@ -5,8 +5,10 @@ namespace Dangl.Data.Shared
     /// <summary>
     /// A <see cref="RepositoryResult"/> returns data from the Repository layer
     /// </summary>
-    public class RepositoryResult<T>
+    public class RepositoryResult<TResult, TError>
     {
+        private const string UnknownError = "Unknown Error";
+
         private RepositoryResult() { }
 
         /// <summary>
@@ -17,52 +19,122 @@ namespace Dangl.Data.Shared
         /// <summary>
         /// The result of the operation
         /// </summary>
-        public T Value { get; private set; }
+        public TResult Value { get; private set; }
 
         /// <summary>
-        /// Null if no error occurred
+        /// The operation error, if error occurred, null if no error occurred
+        /// </summary>
+        public TError Error { get; private set; }
+
+        /// <summary>
+        /// The message describing the operation failure, The message describing the operation failure, null if no error occurred
         /// </summary>
         public string ErrorMessage { get; private set; }
 
         /// <summary>
-        /// Creates an unsuccessfull result
+        /// Creates an unsuccessful result
         /// </summary>
-        /// <param name="errorMessage"></param>
-        /// <returns></returns>
-        public static RepositoryResult<T> Fail(string errorMessage)
+        /// <param name="error">Typed error data</param>
+        /// <param name="errorMessage">An explanatory message to describe the error</param>
+        /// <exception cref="ArgumentNullException">When <paramref name="error"/> is null</exception>
+        /// <returns>The object representing the unsuccessful result</returns>
+        public static RepositoryResult<TResult, TError> Fail(TError error, string errorMessage = null)
         {
-            return new RepositoryResult<T>
+            if (error == null)
+            {
+                throw new ArgumentNullException(nameof(error));
+            }
+
+            return new RepositoryResult<TResult, TError>
             {
                 IsSuccess = false,
-                ErrorMessage = errorMessage
-            };
-        }
-        
-        /// <summary>
-        /// Creates an unsuccessfull result with an unknown error
-        /// </summary>
-        /// <returns></returns>
-        public static RepositoryResult<T> Fail()
-        {
-            return new RepositoryResult<T>
-            {
-                IsSuccess = false,
-                ErrorMessage = "Unknown Error"
+                Error = error,
+                ErrorMessage = errorMessage ?? UnknownError
             };
         }
 
         /// <summary>
-        /// Creates a successfull result
+        /// Creates a successful result
         /// </summary>
-        /// <param name="value"></param>
-        /// <returns></returns>
-        public static RepositoryResult<T> Success(T value)
+        /// <param name="value">The value to return when the result is successful</param>
+        /// <exception cref="ArgumentNullException">When <paramref name="value"/> is null</exception>
+        /// <returns>The object representing the successful result</returns>
+        public static RepositoryResult<TResult, TError> Success(TResult value)
         {
             if (value == null)
             {
                 throw new ArgumentNullException(nameof(value));
             }
-            return new RepositoryResult<T>
+
+            return new RepositoryResult<TResult, TError>
+            {
+                IsSuccess = true,
+                Value = value
+            };
+        }
+    }
+
+    /// <summary>
+    /// A <see cref="RepositoryResult"/> returns data from the Repository layer
+    /// </summary>
+    public class RepositoryResult<TResult>
+    {
+        private const string UnknownError = "Unknown Error";
+
+        private RepositoryResult() { }
+
+        /// <summary>
+        /// Indicates if the operation was successful
+        /// </summary>
+        public bool IsSuccess { get; private set; }
+
+        /// <summary>
+        /// The result of the operation
+        /// </summary>
+        public TResult Value { get; private set; }
+
+        /// <summary>
+        /// The message describing the operation failure, null if no error occurred
+        /// </summary>
+        public string ErrorMessage { get; private set; }
+
+        /// <summary>
+        /// Creates an unsuccessful result
+        /// </summary>
+        /// <param name="errorMessage">An explanatory message to describe the error</param>
+        /// <returns>The object representing the unsuccessful result</returns>
+        public static RepositoryResult<TResult> Fail(string errorMessage) =>
+            new RepositoryResult<TResult>
+            {
+                IsSuccess = false,
+                ErrorMessage = errorMessage
+            };
+
+        /// <summary>
+        /// Creates an unsuccessful result with an unknown error
+        /// </summary>
+        /// <returns>The object representing the unsuccessful result</returns>
+        public static RepositoryResult<TResult> Fail() =>
+            new RepositoryResult<TResult>
+            {
+                IsSuccess = false,
+                ErrorMessage = UnknownError
+            };
+
+        /// <summary>
+        /// Creates a successful result
+        /// </summary>
+        /// <param name="value">The value to return when the result is successful</param>
+        /// <exception cref="ArgumentNullException">When <paramref name="value"/> is null</exception>
+        /// <returns>The object representing the successful result</returns>
+        public static RepositoryResult<TResult> Success(TResult value)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            return new RepositoryResult<TResult>
             {
                 IsSuccess = true,
                 Value = value
@@ -75,55 +147,51 @@ namespace Dangl.Data.Shared
     /// </summary>
     public class RepositoryResult
     {
+        private const string UnknownError = "Unknown Error";
+
         private RepositoryResult() { }
-        
+
         /// <summary>
         /// Indicates if the operation was successful
         /// </summary>
         public bool IsSuccess { get; private set; }
-        
+
         /// <summary>
-        /// Null if no error occurred
+        /// The message describing the operation failure, null if no error occurred
         /// </summary>
         public string ErrorMessage { get; private set; }
 
         /// <summary>
-        /// Creates an unsuccessfull result
+        /// Creates an unsuccessful result
         /// </summary>
-        /// <param name="errorMessage"></param>
-        /// <returns></returns>
-        public static RepositoryResult Fail(string errorMessage)
-        {
-            return new RepositoryResult
+        /// <param name="errorMessage">An explanatory message to describe the error</param>
+        /// <returns>The object representing the unsuccessful result</returns>
+        public static RepositoryResult Fail(string errorMessage) =>
+            new RepositoryResult
             {
                 IsSuccess = false,
                 ErrorMessage = errorMessage
             };
-        }
 
         /// <summary>
-        /// Creates an unsuccessfull result with an unknown error
+        /// Creates an unsuccessful result with an unknown error
         /// </summary>
-        /// <returns></returns>
-        public static RepositoryResult Fail()
-        {
-            return new RepositoryResult
+        /// <returns>A object representing the fail result</returns>
+        public static RepositoryResult Fail() =>
+            new RepositoryResult
             {
                 IsSuccess = false,
-                ErrorMessage = "Unknown Error"
+                ErrorMessage = UnknownError
             };
-        }
 
         /// <summary>
-        /// Creates a successfull result
+        /// Creates a successful result
         /// </summary>
-        /// <returns></returns>
-        public static RepositoryResult Success()
-        {
-            return new RepositoryResult
+        /// <returns>The object representing the successful result</returns>
+        public static RepositoryResult Success() =>
+            new RepositoryResult
             {
                 IsSuccess = true
             };
-        }
     }
 }

--- a/test/Dangl.Data.Shared.Tests/RepositoryResultTests.cs
+++ b/test/Dangl.Data.Shared.Tests/RepositoryResultTests.cs
@@ -5,6 +5,99 @@ namespace Dangl.Data.Shared.Tests
 {
     public class RepositoryResultTests
     {
+        public class GenericFailTests
+        {
+            [Fact]
+            public void ReturnsSuccessOnSuccess()
+            {
+                var result = RepositoryResult<string, object>.Success("Hello");
+                Assert.True(result.IsSuccess);
+                Assert.Null(result.Error);
+                Assert.Null(result.ErrorMessage);
+                Assert.Equal("Hello", result.Value);
+            }
+
+            [Fact]
+            public void ReturnsSuccessPrimitiveType()
+            {
+                var result = RepositoryResult<int, object>.Success(5);
+                Assert.Equal(5, result.Value);
+            }
+
+            [Fact]
+            public void ReturnsErrorPrimitiveType()
+            {
+                var result = RepositoryResult<int, int>.Fail(5);
+                Assert.Equal(5, result.Error);
+            }
+
+            [Fact]
+            public void ReturnsDefaultForNonNullableTypeOnFail()
+            {
+                var resultInt = RepositoryResult<int, string>.Fail("Error data");
+                Assert.Equal(default, resultInt.Value);
+                var resultDouble = RepositoryResult<double, string>.Fail("Error data");
+                Assert.Equal(default, resultDouble.Value);
+                var resultDateTime = RepositoryResult<DateTime, string>.Fail("Error data");
+                Assert.Equal(default, resultDateTime.Value);
+                var resultGuid = RepositoryResult<Guid, string>.Fail("Error data");
+                Assert.Equal(default, resultGuid.Value);
+            }
+
+            [Fact]
+            public void ReturnsDefaultErrorForNonNullableTypeOnSuccess()
+            {
+                var resultInt = RepositoryResult<int, int>.Success(1);
+                Assert.Equal(default, resultInt.Error);
+                var resultDouble = RepositoryResult<int, double>.Success(1);
+                Assert.Equal(default, resultDouble.Error);
+                var resultDateTime = RepositoryResult<int, DateTime>.Success(1);
+                Assert.Equal(default, resultDateTime.Error);
+                var resultGuid = RepositoryResult<int, Guid>.Success(1);
+                Assert.Equal(default, resultGuid.Error);
+            }
+
+            [Fact]
+            public void ArgumentNullExceptionOnNullValueForSuccess()
+            {
+                Assert.Throws<ArgumentNullException>("value", () => RepositoryResult<string, object>.Success(null));
+            }
+
+            [Fact]
+            public void ArgumentNullExceptionOnNullErrorForFail()
+            {
+                Assert.Throws<ArgumentNullException>("error", () => RepositoryResult<string, object>.Fail(null));
+            }
+
+            [Fact]
+            public void ReturnsNoSuccessOnFail()
+            {
+                var result = RepositoryResult<string, object>.Fail("Error object", "Error");
+                Assert.False(result.IsSuccess);
+                Assert.Equal("Error object", result.Error);
+                Assert.Equal("Error", result.ErrorMessage);
+                Assert.Null(result.Value);
+            }
+
+            [Fact]
+            public void ReturnsUnknownErrorOnNoErrorMessage()
+            {
+                var result = RepositoryResult<string, object>.Fail("Error data");
+                Assert.False(result.IsSuccess);
+                Assert.Equal("Error data", result.Error);
+                Assert.Equal("Unknown Error", result.ErrorMessage);
+                Assert.Null(result.Value);
+            }
+
+            [Fact]
+            public void ReturnsCorrectValueOnSuccess()
+            {
+                var value = new object();
+                var result = RepositoryResult<object, object>.Success(value);
+                Assert.Equal(value, result.Value);
+            }
+        }
+
         public class GenericTests
         {
             [Fact]

--- a/test/Dangl.Data.Shared.Tests/RepositoryResultTests.cs
+++ b/test/Dangl.Data.Shared.Tests/RepositoryResultTests.cs
@@ -96,6 +96,14 @@ namespace Dangl.Data.Shared.Tests
                 var result = RepositoryResult<object, object>.Success(value);
                 Assert.Equal(value, result.Value);
             }
+
+            [Fact]
+            public void ReturnsCorrectValueOnCast()
+            {
+                var value = new object();
+                RepositoryResult<object, object> result = value;
+                Assert.Equal(value, result.Value);
+            }
         }
 
         public class GenericTests
@@ -158,6 +166,14 @@ namespace Dangl.Data.Shared.Tests
             {
                 var value = new object();
                 var result = RepositoryResult<object>.Success(value);
+                Assert.Equal(value, result.Value);
+            }
+
+            [Fact]
+            public void ReturnsCorrectValueOnCast()
+            {
+                var value = new object();
+                RepositoryResult<object> result = value;
                 Assert.Equal(value, result.Value);
             }
         }


### PR DESCRIPTION
- Generic RepositoryResult on the error side
- Cast values to the generic RepositoryResult variations
